### PR TITLE
Remove references to deprecated endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 
 Gather PagerDuty webhook IP safelist from their help documents repo.
 
-This replaces an extremely useful endpoint being removed on 05/05/2022 at 14:00UTC.
-
 IPs pulled can include both US and EU ranges or from a specific region.
-Until 05/05/2022 both sources of truth are pulled and compiled into a single return.
 
 Support Documentation:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pd_ip_gatherer
-version = 1.0.4
+version = 1.0.5
 description = Gather PagerDuty webhook IP safelist from their help documents repo
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Post 05.05.2022 the deprecated endpoint for gathering IP safelist will be removed. This change stages the cleanup of the code.

Will not be merged until after 05.05.2022