### PR TITLE
Preocts 20220614 setuptools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Batch of helpful formatters and patterns
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.2.0"
+    rev: "v4.3.0"
     hooks:
       - id: check-json
       - id: check-toml
@@ -49,6 +49,6 @@ repos:
 
   # Type enforcement for Python
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.960
+    rev: v0.961
     hooks:
       - id: mypy

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,23 @@
 .PHONY: init
 init:
-	pip install --upgrade pip flit
+	python -m pip install --upgrade pip setuptools wheel
 
 .PHONY: install
 install:
 	[ -f "requirements.txt" ] && pip install -r requirements.txt || true
-	flit install
+	python -m pip install --upgrade .
 
 .PHONY: install-dev
 install-dev:
 	[ -f "requirements.txt" ] && pip install -r requirements.txt || true
 	[ -f "requirements-dev.txt" ] && pip install -r requirements-dev.txt || true
-	flit install --symlink
+	python -m pip install --editable .
 	pre-commit install
 
 .PHONY: build-dist
 build-dist:
-	flit build
+	pip install --upgrade build
+	python -m build
 
 .PHONY: clean-artifacts
 clean-artifacts:

--- a/README.md
+++ b/README.md
@@ -118,16 +118,16 @@ Install editable library and development requirements:
 
 ```bash
 # Update pip and install flit
-python -m pip install --upgrade pip flit
+python -m pip install --upgrade pip setuptools
 
 # Install development requirements
 python -m pip install -r requirements-dev.txt
 
 # Install package
-flit install
+python -m pip install .
 
-# Optional: install editable package (pip install -e)
-flit install --symlink
+# Optional: install editable package
+python -m pip install --editable .
 ```
 
 Install pre-commit [(see below for details)](#pre-commit):
@@ -190,11 +190,11 @@ Makefile.
 
 | PHONY             | Description                                                        |
 | ----------------- | ------------------------------------------------------------------ |
-| `init`            | Install/Update pip and flit                                        |
+| `init`            | Install/Update pip and setuptools                                  |
 | `install`         | install project and requirements                                   |
 | `install-dev`     | install dev requirements, project as editable, and pre-commit      |
 | `build-dist`      | Build source distribution and wheel distribution                   |
-| `clean-artifacts` | Deletes python/mypy artifacts including eggs, cache, and pyc files |
+| `clean-artifacts` | Deletes python/mypy artifacts, cache, and pyc files                |
 | `clean-tests`     | Deletes tox, coverage, and pytest artifacts                        |
 | `clean-build`     | Deletes build artifacts                                            |
 | `clean-all`       | Runs all clean scripts                                             |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "pd_ip_gatherer"
-version = "1.0.6"
+version = "1.0.7"
 requires-python = ">=3.8"
 description = "Gather PagerDuty webhook IP safelist from their help documents repo"
 readme = "README.md"
@@ -37,6 +37,14 @@ homepage = "https://github.com/Preocts/pagerduty-safelist-gatherer"
 
 [project.scripts]
 pd-ip-gatherer = "pd_ip_gatherer:_console_output"
+
+# Use only for package discovery with single distro of multiple packages.
+# Let setuptools handle the rest.
+# [tool.setuptools.packages.find]
+# where = ["."]  # ["."] by default
+# include = ["*"]  # ["*"] by default
+# exclude = ["tests"]  # empty by default
+# namespaces = true  # true by default
 
 [tool.mypy]
 check_untyped_defs = true

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+"""Legacy for setuptools editable install only"""
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Updating new `pyproject.toml` to use `setuptools` over `flit` for better backward compatibility of installs. Includes `setup.py` for older `pip` versions.